### PR TITLE
Example css preprocessor configuration for less

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # PatternPack Example Library specific
 src/assets/css/patterns.css*
 src/assets/sass/patternpack-patterns.scss
+src/assets/less/patternpack-patterns.less
 
 # Project directories
 node_modules/

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,7 +2,8 @@ module.exports = function (grunt) {
   grunt.initConfig({
     patternpack: {
       options: {
-        assets: "./src/assets"
+        assets: "./src/assets",
+        cssPreprocessor: "less"
 
         // Add a custom theme by pointing to the location of the theme files
         // This can be added to your pattern library or in an external repository

--- a/src/assets/less/patterns.less
+++ b/src/assets/less/patterns.less
@@ -1,0 +1,1 @@
+@import "patternpack-patterns"; // Built by sass-globbing

--- a/src/atoms/buttons.less
+++ b/src/atoms/buttons.less
@@ -1,0 +1,4 @@
+.button--primary {
+  background-color: black;
+  color: white;
+}


### PR DESCRIPTION
In order for this to work the base pattern pack project must have support.  It is currently in the `feature/less` branch, so additional setup may be required until it is merged into master.

In order to use this feature, less files will need to be added in `assets/less`.  The same configuration as used in sass must be followed for less.
- `pattern.less` - the main style entry point
- `patternpack-pattern.less` - automatically generated and should be imported by `patterns.less`

**gruntfile.js**

``` js
patternpack: {
  options: {
    cssPreprocessor: "less"
  }
}
```
